### PR TITLE
Adapted README.MD - Removed JSON.NET

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,6 @@ Note: replace "replace-with-username", "replace-with-user-api-key", "replace-wit
 
 [RestSharp](https://www.nuget.org/packages/RestSharp/) (>= 105.1.0)
 
-[Json.NET](https://www.nuget.org/packages/Newtonsoft.Json/) (>= 7.0.1)
-
-Please note: in case you have a Newtonsoft.Json library version conflict preventing the library to compile, update this package with the NuGet Package Manager Console:
-
-    $ Update-Package Newtonsoft.Json
-
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/textmagic/textmagic-rest-csharp.


### PR DESCRIPTION
Deleted dependency to JSON.NET, because RestSharp does not rely on it anymore.
