### PR TITLE
Upgrade RestSharp and target .NET Framework 4.6.1

### DIFF
--- a/TextmagicRest.Examples/App.config
+++ b/TextmagicRest.Examples/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
 </configuration>

--- a/TextmagicRest.Examples/TextmagicRest.Examples.csproj
+++ b/TextmagicRest.Examples/TextmagicRest.Examples.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TextmagicRest.Examples</RootNamespace>
     <AssemblyName>TextmagicRest.Examples</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/TextmagicRest.Tests/Common.cs
+++ b/TextmagicRest.Tests/Common.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using RestSharp;
+﻿using RestSharp;
 using System.Net;
 using Moq;
-using RestSharp.Deserializers;
+using RestSharp.Serialization.Json;
 
 namespace TextmagicRest.Tests
 {

--- a/TextmagicRest.Tests/TextmagicRest.Tests.csproj
+++ b/TextmagicRest.Tests/TextmagicRest.Tests.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TextmagicRest.Tests</RootNamespace>
     <AssemblyName>TextmagicRest.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/TextmagicRest.Tests/TextmagicRest.Tests.csproj
+++ b/TextmagicRest.Tests/TextmagicRest.Tests.csproj
@@ -55,12 +55,12 @@
       <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.1.0\lib\net45\RestSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="RestSharp, Version=106.13.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.13.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/TextmagicRest.Tests/packages.config
+++ b/TextmagicRest.Tests/packages.config
@@ -3,5 +3,5 @@
   <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
-  <package id="RestSharp" version="105.1.0" targetFramework="net45" />
+  <package id="RestSharp" version="105.1.0" targetFramework="net45" requireReinstallation="true" />
 </packages>

--- a/TextmagicRest.Tests/packages.config
+++ b/TextmagicRest.Tests/packages.config
@@ -3,5 +3,5 @@
   <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
-  <package id="RestSharp" version="105.1.0" targetFramework="net45" requireReinstallation="true" />
+  <package id="RestSharp" version="106.13.0" targetFramework="net461" />
 </packages>

--- a/TextmagicRest/TextmagicAuthenticator.cs
+++ b/TextmagicRest/TextmagicAuthenticator.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using RestSharp;
+﻿using RestSharp;
+using RestSharp.Authenticators;
 
 namespace TextmagicRest
 {

--- a/TextmagicRest/TextmagicRest.csproj
+++ b/TextmagicRest/TextmagicRest.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TextmagicRest</RootNamespace>
     <AssemblyName>TextmagicRest</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/TextmagicRest/TextmagicRest.csproj
+++ b/TextmagicRest/TextmagicRest.csproj
@@ -31,12 +31,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.1.0\lib\net45\RestSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="RestSharp, Version=106.13.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.13.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/TextmagicRest/packages.config
+++ b/TextmagicRest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="105.1.0" targetFramework="net45" />
+  <package id="RestSharp" version="105.1.0" targetFramework="net45" requireReinstallation="true" />
 </packages>

--- a/TextmagicRest/packages.config
+++ b/TextmagicRest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="105.1.0" targetFramework="net45" requireReinstallation="true" />
+  <package id="RestSharp" version="106.13.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
We usen TextMagicRest in our project, but want to upgrade the very old version of RestSharp that is referenced in TextMagic Rest. I have tested this upgraded version in our project and it seems to work as expected. We are planning to use this instead of the existing, old NuGet-package, but it would be great if you could update the official version! :)